### PR TITLE
Add shape of avatars

### DIFF
--- a/rationale/rationale.md
+++ b/rationale/rationale.md
@@ -28,7 +28,7 @@ response to questions or confusion within the Tox development community.
 - **2.3.3** PNG images are currently the only image type supported by the Tox
   core library.
 
-- **2.3.8** This will ensure that the avatar is unset for all of the user's
+- **2.3.10** This will ensure that the avatar is unset for all of the user's
   friends (as long as their clients comply with the avatar protocol as
   described in this document).
 

--- a/user_identification/avatar.md
+++ b/user_identification/avatar.md
@@ -15,21 +15,25 @@ Avatar support in Tox clients is not required. The points below are applicable o
 - **2.3.4** ![](/badge/req.png) The maximum size of the encoded avatar data is 65536
   bytes (64KiB).
 
-- **2.3.5** ![](/badge/req.png) The user must be allowed to unset the avatar.
+- **2.3.5** ![](/badge/req.png) Clients must display avatars at a 1:1 aspect ratio.
 
-- **2.3.6** ![](/badge/req.png) When a friend comes online, and an avatar is set, the
+- **2.3.6** ![](/badge/req.png) A client may only transmit avatars with an aspect ratio of 1:1. If the user has chosen a non-square avatar, the client must transmit the square portion of the avatar displayed to the user. In the case that the user's client doesn't display avatars, the client must pad the avatar evenly on two sides with transparent rectangles, in order to create a square.
+
+- **2.3.7** ![](/badge/req.png) The user must be allowed to unset the avatar.
+
+- **2.3.8** ![](/badge/req.png) When a friend comes online, and an avatar is set, the
   client will send a file transfer of type `TOX_FILE_KIND_AVATAR`, where the
   file ID is the hash of the avatar data that will be sent.
 
-- **2.3.7** ![](/badge/req.png) When a user sets a new avatar, the client will send a
+- **2.3.9** ![](/badge/req.png) When a user sets a new avatar, the client will send a
   file transfer of type `TOX_FILE_KIND_AVATAR` to all friends, where the file
   ID is the hash of the avatar data that will be sent.
 
-- **2.3.8** ![](/badge/req.png) When a user unsets an avatar, the client will send an
+- **2.3.10** ![](/badge/req.png) When a user unsets an avatar, the client will send an
   avatar file transfer of size 0 to all friends. In this case, the file ID is
   undefined.
 
-- **2.3.9** ![](/badge/req.png) When a file transfer of type `TOX_FILE_KIND_AVATAR` is received:
+- **2.3.11** ![](/badge/req.png) When a file transfer of type `TOX_FILE_KIND_AVATAR` is received:
     - The client must check the file ID against a previously-saved hash of the
       friend's avatar. If it is the same, the client must cancel the transfer,
       and use the previously-stored avatar.


### PR DESCRIPTION
Closes #11.

With that change, the visible area of the avatars will be equal (no matter which client you're using).
