### PR TITLE
Expand on and improve message persistence clauses

### DIFF
--- a/message_persistence/message_persistence.md
+++ b/message_persistence/message_persistence.md
@@ -14,5 +14,5 @@ Message Persistence
 
 - **4.0.3** ![](/badge/req.png) If message persistence is enabled by default,
   all message logs stored on the device must be encrypted using the cryptography
-  functions provided by the Tox API, or a comparibly reputable, free and open
+  functions provided by the Tox API, or a comparably reputable, free and open
   source cryptography library.

--- a/message_persistence/message_persistence.md
+++ b/message_persistence/message_persistence.md
@@ -11,8 +11,7 @@ Message Persistence
     default.
   - If stored message logs are not encrypted, clients must make the user aware
     of this fact if they enable message persistence.
-
-- **4.0.3** ![](/badge/req.png) If message persistence is enabled by default,
-  all message logs stored on the device must be encrypted using the cryptography
-  functions provided by the Tox API, or a comparably reputable, free and open
-  source cryptography library.
+  - ![](/badge/req.png) If message persistence is enabled by default,
+    all message logs stored on the device must be encrypted using the cryptography
+    functions provided by the Tox API, or a comparably reputable, free and open
+    source cryptography library.

--- a/message_persistence/message_persistence.md
+++ b/message_persistence/message_persistence.md
@@ -1,10 +1,18 @@
 Message Persistence
 ===================
 
-- **4.0.1** ![](/badge/rec.png) A client should provide an option to save its message
-  history, and provide a persistent view of that history across client
+- **4.0.1** ![](/badge/rec.png) A client should provide the ability to save its
+  message history, and provide a persistent view of that history across client
   restarts.
 
-- **4.0.2** ![](/badge/rec.png) Message persistence should be disabled by default.
+- **4.0.2** ![](/badge/rec.png) Message persistence should be disabled by
+  default.
+  - Clients may provide users with a setting to enable message persistence by
+    default.
+  - If stored message logs are not encrypted, clients must make the user aware
+    of this fact if they enable message persistence.
 
-- **4.0.3** ![](/badge/rec.png) Message history stored on disk should be encrypted.
+- **4.0.3** ![](/badge/req.png) If message persistence is enabled by default,
+  all message logs stored on the device must be encrypted using the cryptography
+  functions provided by the Tox API, or a comparibly reputable, free and open
+  source cryptography library.


### PR DESCRIPTION
This change gives clients two options: Disable default auto-logging, or enable default auto-logging but encrypt the logs. 

This is to prevent the very possible scenario where someone may be unknowingly collecting plaintext records of  all of their Tox conversations and sharing their device with other people (or losing it). We want users to be able to make a fully informed decision regarding their message logs.
