### PR TITLE
Clients must give users option to encrypt profile on creation

### DIFF
--- a/data_storage/data_storage.md
+++ b/data_storage/data_storage.md
@@ -4,7 +4,7 @@ Data Storage
 A client is allowed to store profile data internally in any format.
 
 - **5.0.1** ![](/badge/req.png) A client must give the user the option to encrypt their
-  profile data.
+  .tox data file.
   - This option must be presented on creation of a new profile.
 
 - **5.0.2** ![](/badge/rec.png) A client should give the user the option to decrypt

--- a/data_storage/data_storage.md
+++ b/data_storage/data_storage.md
@@ -5,6 +5,7 @@ A client is allowed to store profile data internally in any format.
 
 - **5.0.1** ![](/badge/req.png) A client must give the user the option to encrypt their
   profile data.
+  - This option must be presented on creation of a new profile.
 
 - **5.0.2** ![](/badge/rec.png) A client should give the user the option to decrypt
   encrypted profile data.

--- a/rationale/rationale.md
+++ b/rationale/rationale.md
@@ -51,3 +51,7 @@ response to questions or confusion within the Tox development community.
 - **4.0.2** As message history may be stored on a user's device in plaintext,
   it is a matter of security to ensure that this does not occur without the
   user's explicit consent.
+
+- **5.0.1** The .tox data file contains all of the information required to steal
+  a user's identity. Therefore users should always have and be aware of the
+  option to encrypt this file.


### PR DESCRIPTION
This is to ensure that all users are made aware of the fact that profile encryption is an option.
