### PR TITLE
Increase avatar file size limit

### DIFF
--- a/user_identification/avatar.md
+++ b/user_identification/avatar.md
@@ -12,8 +12,8 @@ Avatar support in Tox clients is not required. The points below are applicable o
 
 - **2.2.3** ![](/badge/req.png) Avatars must be PNG images.
 
-- **2.2.4** ![](/badge/req.png) The maximum size of the encoded avatar data is 65536
-  bytes (64KiB).
+- **2.2.4** ![](/badge/req.png) The maximum size of the encoded avatar data is 5242880
+  bytes (5MiB.)
 
 - **2.2.5** ![](/badge/req.png) Clients must display avatars at a 1:1 aspect ratio.
 


### PR DESCRIPTION
64 KB is really small for a picture these days. I expect the average user to take a picture of themselves and select it in a Tox client. On my webcam and front facing phone camera, the pictures are about 300 KB. On my phone's back facing camera, I took a 1.9 MB picture. To add some amount of future proofing given increasingly better cameras and faster internet speeds, 5 MB seems like a reasonable limit for the avatar size.
